### PR TITLE
fix: next crash because of window error

### DIFF
--- a/src/DrupalPreviewBanner/index.tsx
+++ b/src/DrupalPreviewBanner/index.tsx
@@ -20,7 +20,7 @@ interface DrupalPreviewBannerProps {
 }
 
 export default function DrupalPreviewBanner (props: DrupalPreviewBannerProps): React.JSX.Element {
-  const mediaMatch = window.matchMedia('(max-width: 1024px)');
+  const mediaMatch = typeof window !== 'undefined' ? window.matchMedia('(max-width: 1024px)') : { matches: false } as MediaQueryList;
   const [matches, setMatches] = useState(mediaMatch.matches);
 
   useEffect(() => {


### PR DESCRIPTION
**What?**
Simple check to see if window is defined 

**Why?**
Next gets mad when it server renders about the window not existing  